### PR TITLE
Fix markdown lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ If you checked out the project from GitHub you can build the project with maven 
 ```
 mvn clean install
 ```
+
 If you want to generate the jar from GitHub you run the following maven command:
+
 ```
 mvn package
 ```
-**NOTE** the jar file can be found in `javaparser/javaparser-core/target/javaparser-core-\<version\>-SNAPSHOT.jar
+
+**NOTE** the jar file can be found in `javaparser/javaparser-core/target/javaparser-core-\<version\>-SNAPSHOT.jar`
 
 If you checkout the sources and want to view the project in an IDE, it is best to first generate some of the source files; otherwise you will get many compilation complaints in the IDE. (mvn clean install already does this for you.)
 


### PR DESCRIPTION
This PR makes the style in `README.md` consistent to the other places. Furthermore, it adds a forgotten backtick.

Hint: For markdown editing, activate [markdownlint](https://github.com/DavidAnson/markdownlint).